### PR TITLE
fix: broker request viewer issues #13–#16 + config dialog rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apikey-manager-gui",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Cross-platform desktop app to manage API keys of the AKTIN Broker",
   "author": "Daniel Kombeiz <dkombeiz@ukaachen.de>",
   "contributors": [

--- a/src/components/BrokerProfileManager.vue
+++ b/src/components/BrokerProfileManager.vue
@@ -256,64 +256,67 @@ onMounted(async () => {
   />
 
   <!-- Profile manager dialog -->
-  <Dialog
-    v-model:visible="visible"
-    modal
-    :header="t('config')"
-    class="w-30rem h-25rem"
-  >
+  <Dialog v-model:visible="visible" modal :header="t('config')" class="w-30rem">
     <!-- Show loading spinner during async profile switch -->
-    <div v-if="logInBlocked" class="h-18rem flex align-items-center">
-      <ProgressSpinner class="justify-content-center" />
+    <div
+      v-if="logInBlocked"
+      class="flex align-items-center justify-content-center"
+      style="min-height: 14rem"
+    >
+      <ProgressSpinner />
     </div>
 
-    <div v-else class="flex flex-row flex-wrap h-18rem">
-      <!-- Input fields: name, key, URL -->
-      <div class="flex flex-column justify-content-between">
-        <div class="field grid mt-3 p-2 flex flex-wrap align-items-center">
-          <FloatLabel>
-            <InputText v-model="name" class="w-20rem" />
-            <label>{{ t("profileName") }}</label>
-          </FloatLabel>
-        </div>
+    <!-- Input fields: name, key, URL (all equal width) -->
+    <div v-else class="flex flex-column gap-5">
+      <FloatLabel class="w-full mt-4">
+        <InputText v-model="name" class="w-full" />
+        <label>{{ t("profileName") }}</label>
+      </FloatLabel>
 
-        <div class="field grid p-2 flex flex-wrap align-items-center">
-          <FloatLabel>
-            <Password v-model="key" toggleMask :feedback="false" />
-            <label>{{ t("profileKey") }}</label>
-          </FloatLabel>
-        </div>
+      <FloatLabel class="w-full">
+        <Password
+          v-model="key"
+          toggleMask
+          :feedback="false"
+          class="w-full"
+          input-class="w-full"
+        />
+        <label>{{ t("profileKey") }}</label>
+      </FloatLabel>
 
-        <div class="field grid p-2 flex flex-wrap align-items-center">
-          <FloatLabel>
-            <InputText v-model="url" class="w-20rem" />
-            <label>{{ t("profileUrl") }}</label>
-          </FloatLabel>
-        </div>
-      </div>
+      <FloatLabel class="w-full">
+        <InputText v-model="url" class="w-full" />
+        <label>{{ t("profileUrl") }}</label>
+      </FloatLabel>
+    </div>
 
-      <!-- Side controls: language switch, save/delete/select -->
-      <div class="flex flex-column justify-content-between ml-auto">
+    <!-- Footer: language switch (left) + grouped profile actions (right) -->
+    <template #footer>
+      <div class="flex align-items-center w-full">
         <LanguageSwitcher />
-        <Button
-          icon="pi pi-save"
-          @click="saveOrUpdateProfile"
-          :disabled="saveBtnDisabled"
-          v-tooltip.bottom="t('saveProfile')"
-        />
-        <Button
-          icon="pi pi-trash"
-          @click="confirmDelete"
-          :disabled="deleteBtnDisabled"
-          v-tooltip.bottom="t('deleteProfile')"
-        />
-        <Button
-          icon="pi pi-arrow-right-arrow-left"
-          @click="openProfileSelectionMenu"
-          v-tooltip.bottom="t('selectProfile')"
-        />
+        <div class="flex gap-2 ml-auto">
+          <Button
+            icon="pi pi-arrow-right-arrow-left"
+            severity="secondary"
+            @click="openProfileSelectionMenu"
+            v-tooltip.bottom="t('selectProfile')"
+          />
+          <Button
+            icon="pi pi-save"
+            @click="saveOrUpdateProfile"
+            :disabled="saveBtnDisabled"
+            v-tooltip.bottom="t('saveProfile')"
+          />
+          <Button
+            icon="pi pi-trash"
+            severity="danger"
+            @click="confirmDelete"
+            :disabled="deleteBtnDisabled"
+            v-tooltip.bottom="t('deleteProfile')"
+          />
+        </div>
         <Menu ref="profilesMenu" :model="profilesList" :popup="true" />
       </div>
-    </div>
+    </template>
   </Dialog>
 </template>

--- a/src/components/BrokerRequestViewer.vue
+++ b/src/components/BrokerRequestViewer.vue
@@ -84,8 +84,20 @@ const exec = computed<execView | null>(() => {
   return null;
 });
 
-const columns = computed(() => {
+const nodeSearch = ref("");
+
+// Filters nodes by the displayed label (#id + CN), case-insensitive.
+const filteredStatus = computed(() => {
   const all = requestStatus.value ?? [];
+  const q = nodeSearch.value.trim().toLowerCase();
+  if (!q) return all;
+  return all.filter((n) =>
+    `${n.nodeId} ${nodeLabel(n.nodeId)}`.toLowerCase().includes(q)
+  );
+});
+
+const columns = computed(() => {
+  const all = filteredStatus.value;
   const half = Math.ceil(all.length / 2);
   return { left: all.slice(0, half), right: all.slice(half) };
 });
@@ -280,6 +292,17 @@ onMounted(async () => {
         </p>
       </div>
     </div>
+  </div>
+
+  <div
+    v-if="requestStatus && requestStatus.length"
+    class="flex justify-content-center mt-3"
+  >
+    <InputText
+      v-model="nodeSearch"
+      :placeholder="t('keywordSearch')"
+      class="w-20rem"
+    />
   </div>
 
   <div

--- a/src/components/BrokerRequestViewer.vue
+++ b/src/components/BrokerRequestViewer.vue
@@ -191,6 +191,17 @@ async function openNodeStatus(nodeIdNum: number) {
   }
 }
 
+/** Copies the open node status message to the clipboard. */
+async function copyStatusToClipboard(): Promise<void> {
+  if (!statusDialogText.value) return;
+  try {
+    await navigator.clipboard.writeText(statusDialogText.value);
+    createSuccessToast(toast, t("success"), t("statusCopied"));
+  } catch {
+    createErrorToast(toast, t("error"), t("failedToCopy"));
+  }
+}
+
 onMounted(async () => {
   await BrokerConnection.waitForBrokerCredentials();
   await BrokerConnection.refreshNodeCache();
@@ -308,10 +319,24 @@ onMounted(async () => {
 
   <Dialog
     v-model:visible="statusDialogVisible"
-    :header="statusDialogTitle"
     modal
     style="width: 60vw; max-width: 900px"
   >
+    <template #header>
+      <span class="flex align-items-center gap-2">
+        <span class="font-bold">{{ statusDialogTitle }}</span>
+        <Button
+          v-if="statusDialogText"
+          icon="pi pi-copy"
+          text
+          rounded
+          size="small"
+          v-tooltip.bottom="t('copyStatusMessage')"
+          @click="copyStatusToClipboard"
+        />
+      </span>
+    </template>
+
     <div v-if="statusLoading" class="flex justify-content-center p-4">
       <ProgressSpinner />
     </div>

--- a/src/components/NodeCredsForm.vue
+++ b/src/components/NodeCredsForm.vue
@@ -43,7 +43,9 @@ const invalidLoc = ref(false);
 // Validation rules
 const apiKeyLength = 16;
 const apiKeyPattern = /[^a-zA-Z0-9]/;
-const dnPattern = /[^a-zA-Z0-9 -äÄöÖüÜ]/;
+// Allow letters, digits, spaces, German umlauts/ß and common org punctuation;
+// block DN-structural characters ("," and "=") and anything else.
+const dnPattern = /[^a-zA-Z0-9 äöüÄÖÜß&.()\/+-]/;
 
 // Prop from parent: selected key to toggle state
 const props = defineProps<{ selectedKey: string }>();
@@ -99,6 +101,14 @@ function validate() {
   validateField(loc.value, invalidLoc, "l", dnPattern);
 }
 
+/** Escapes XML-special characters so DN values are safe in the clientDn payload. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 async function addNewKey() {
   validate();
   if (
@@ -108,7 +118,7 @@ async function addNewKey() {
     invalidLoc.value
   )
     return;
-  const payload = `CN=${cn.value},O=${org.value},L=${loc.value}`;
+  const payload = `CN=${escapeXml(cn.value)},O=${escapeXml(org.value)},L=${escapeXml(loc.value)}`;
   const xml = `<ApiKeyCred><apiKey>${apiKey.value}</apiKey><clientDn>${payload}</clientDn></ApiKeyCred>`;
   const status = await BrokerConnection.addApiKey(xml);
   if (status === 201) {

--- a/src/components/NodeStatusInfoTimeline.vue
+++ b/src/components/NodeStatusInfoTimeline.vue
@@ -31,13 +31,8 @@ type StateKey = (typeof orderedStates)[number];
 const mostActualState = computed<StateKey | null>(() => {
   const nsi = props.nodeStatusInfo;
   let latestKey: StateKey | null = null;
-  let latestDate: Date | null = null;
   for (const key of orderedStates) {
-    const ts = nsi[key];
-    if (ts && (!latestDate || ts > latestDate)) {
-      latestDate = ts;
-      latestKey = key;
-    }
+    if (nsi[key]) latestKey = key;
   }
   return latestKey;
 });

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -104,5 +104,8 @@
   "error404Title": "Nicht gefunden",
   "error404Description": "Diese Seite spielt Verstecken – und sie gewinnt",
   "error500Title": "Interner Serverfehler",
-  "error500Description": "Entschuldigung, der Server hat gerade einen kleinen Aussetzer"
+  "error500Description": "Entschuldigung, der Server hat gerade einen kleinen Aussetzer",
+  "error": "Fehler",
+  "copyStatusMessage": "Statusmeldung kopieren",
+  "statusCopied": "Statusmeldung kopiert"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -104,5 +104,8 @@
   "error404Title": "Not Found",
   "error404Description": "This page is playing hide-and-seek and it's winning",
   "error500Title": "Internal Server Error",
-  "error500Description": "Sorry, the server is currently having a bit of a meltdown"
+  "error500Description": "Sorry, the server is currently having a bit of a meltdown",
+  "error": "Error",
+  "copyStatusMessage": "Copy status message",
+  "statusCopied": "Status message copied"
 }


### PR DESCRIPTION
## Summary

Fixes issues #13–#16 in the broker request viewer and credential form, plus a UI rework of the broker configuration dialog.

## Changes

- **#13 – Copy button for node status messages** (`feat`): the node status dialog now has a copy button that writes the status message to the clipboard, with localized success/error toasts.
- **#14 – Current node state ranking** (`fix`): the timeline now determines the current state by progression order (last reached state) instead of the latest timestamp.
- **#15 – Node search** (`feat`): the request viewer gained a keyword search that filters nodes by id and CN.
- **#16 – Client DN handling** (`fix`): client DN values are now XML-escaped before being sent, and the allowed character set was widened to include German umlauts/ß and common org punctuation.
- **Config dialog layout** (`style`): removed the fixed dialog heights (no more scrollbar), equalized all input widths, and moved the profile actions into a grouped footer. Bumped version to 2.2.0.

Closes #13
Closes #14
Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
