### PR TITLE
feat: rework api key table toolbar (add dialog, node count, key toggle)

### DIFF
--- a/src/components/NodeCredsForm.vue
+++ b/src/components/NodeCredsForm.vue
@@ -2,23 +2,21 @@
 /**
  * NodeCredsForm.vue
  *
- * Form component to add new API keys or activate/deactivate existing ones.
+ * Self-contained "add API key" feature: an icon button that opens a modal
+ * dialog holding the key-creation form.
  *
  * Features:
  * - Validates API key and DN components (CN, O, L) on input
  * - Generates a secure random API key
  * - Submits a formatted XML payload to the broker
- * - Enables status toggle of the selected key
+ * - Clears the form and closes the dialog on success
  * - Displays toast messages on success/error
- *
- * Props:
- * - `selectedKey`: A semicolon-delimited string of the form "apiKey;isActive"
- *   used to identify and toggle the state of an existing key
  */
-import { computed, Ref, ref, watch } from "vue";
+import { computed, Ref, ref } from "vue";
 import Button from "primevue/button";
 import InputText from "primevue/inputtext";
 import FloatLabel from "primevue/floatlabel";
+import Dialog from "primevue/dialog";
 import BrokerConnection from "../services/BrokerConnection";
 import { useToast } from "primevue/usetoast";
 import { createErrorToast, createSuccessToast } from "../utils/ToastWrapper";
@@ -27,6 +25,8 @@ import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
 const toast = useToast();
+
+const visible = ref(false);
 
 // Form inputs
 const apiKey = ref("");
@@ -47,21 +47,13 @@ const apiKeyPattern = /[^a-zA-Z0-9]/;
 // block DN-structural characters ("," and "=") and anything else.
 const dnPattern = /[^a-zA-Z0-9 äöüÄÖÜß&.()\/+-]/;
 
-// Prop from parent: selected key to toggle state
-const props = defineProps<{ selectedKey: string }>();
-const selectedKey = ref(props.selectedKey);
-
-// Form button states
+// Add button is enabled only when all fields are filled
 const isAddButtonActive = computed(
   () =>
     apiKey.value.trim() !== "" &&
     cn.value.trim() !== "" &&
     org.value.trim() !== "" &&
     loc.value.trim() !== ""
-);
-const isChangeStateButtonActive = computed(() => selectedKey.value !== "");
-const isSelectedKeyActive = computed(
-  () => selectedKey.value.split(";")[1] === "true"
 );
 
 function validateField(
@@ -109,6 +101,13 @@ function escapeXml(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
+function resetForm() {
+  apiKey.value = "";
+  cn.value = "";
+  org.value = "";
+  loc.value = "";
+}
+
 async function addNewKey() {
   validate();
   if (
@@ -123,31 +122,13 @@ async function addNewKey() {
   const status = await BrokerConnection.addApiKey(xml);
   if (status === 201) {
     createSuccessToast(toast, t("success"), t("keyAdded"));
+    resetForm();
+    visible.value = false;
     return;
   }
   notifyStatusError(toast, t, status, {
     404: { title: "notFound", message: "noKeyListFound" },
     409: { title: "conflict", message: "keyAlreadyExists" }
-  });
-}
-
-async function changeKeyState() {
-  const [key, isActive] = selectedKey.value.split(";");
-  selectedKey.value = "";
-  const status =
-    isActive === "false"
-      ? await BrokerConnection.activateApiKey(key)
-      : await BrokerConnection.deactivateApiKey(key);
-  if (status === 200) {
-    createSuccessToast(
-      toast,
-      t("success"),
-      isActive === "false" ? t("keyActivated") : t("keyDeactivated")
-    );
-    return;
-  }
-  notifyStatusError(toast, t, status, {
-    404: { title: "notFound", message: "keyNotFound" }
   });
 }
 
@@ -169,82 +150,75 @@ function generateApiKey() {
   }
   apiKey.value = result.join("");
 }
-
-watch(
-  () => props.selectedKey,
-  (val) => {
-    selectedKey.value = val;
-  }
-);
 </script>
 
 <template>
-  <div class="p-3 w-full">
-    <!-- API key input with generate button -->
-    <div class="flex align-items-center gap-2 mt-3">
+  <Button
+    icon="pi pi-plus"
+    size="small"
+    @click="visible = true"
+    v-tooltip.bottom="t('addKey')"
+  />
+
+  <Dialog v-model:visible="visible" modal :header="t('addKey')" class="w-30rem">
+    <div class="flex flex-column gap-4 pt-4">
+      <!-- API key input with generate button -->
+      <div class="flex align-items-center gap-2">
+        <FloatLabel class="w-full">
+          <InputText
+            id="apiInput"
+            v-model="apiKey"
+            :invalid="invalidApiKey"
+            class="w-full"
+          />
+          <label for="apiInput">{{ t("key") }}</label>
+        </FloatLabel>
+        <Button
+          icon="pi pi-sync"
+          v-tooltip.bottom="t('generateKey')"
+          @click="generateApiKey"
+          class="flex-shrink-0"
+        />
+      </div>
+
+      <!-- DN fields -->
       <FloatLabel class="w-full">
         <InputText
-          id="apiInput"
-          v-model="apiKey"
-          :invalid="invalidApiKey"
+          id="nameInput"
+          v-model="cn"
+          :invalid="invalidCN"
           class="w-full"
         />
-        <label for="apiInput">{{ t("key") }}</label>
+        <label for="nameInput">{{ t("cn") }}</label>
       </FloatLabel>
-      <Button
-        icon="pi pi-sync"
-        v-tooltip.bottom="t('generateKey')"
-        @click="generateApiKey"
-        class="flex-shrink-0"
-      />
+
+      <FloatLabel class="w-full">
+        <InputText
+          id="orgInput"
+          v-model="org"
+          :invalid="invalidOrg"
+          class="w-full"
+        />
+        <label for="orgInput">{{ t("o") }}</label>
+      </FloatLabel>
+
+      <FloatLabel class="w-full">
+        <InputText
+          id="locInput"
+          v-model="loc"
+          :invalid="invalidLoc"
+          class="w-full"
+        />
+        <label for="locInput">{{ t("l") }}</label>
+      </FloatLabel>
     </div>
 
-    <!-- DN Fields -->
-    <FloatLabel class="mt-5 w-full">
-      <InputText
-        id="nameInput"
-        v-model="cn"
-        :invalid="invalidCN"
-        class="w-full"
-      />
-      <label for="nameInput">{{ t("cn") }}</label>
-    </FloatLabel>
-
-    <FloatLabel class="mt-5 w-full">
-      <InputText
-        id="orgInput"
-        v-model="org"
-        :invalid="invalidOrg"
-        class="w-full"
-      />
-      <label for="orgInput">{{ t("o") }}</label>
-    </FloatLabel>
-
-    <FloatLabel class="mt-5 w-full">
-      <InputText
-        id="locInput"
-        v-model="loc"
-        :invalid="invalidLoc"
-        class="w-full"
-      />
-      <label for="locInput">{{ t("l") }}</label>
-    </FloatLabel>
-
-    <!-- Action buttons -->
-    <div class="flex flex-wrap justify-content-between mt-4 gap-2">
+    <template #footer>
       <Button
         :label="t('addKey')"
         @click="addNewKey"
         :disabled="!isAddButtonActive"
-        class="text-sm"
       />
-      <Button
-        :label="isSelectedKeyActive ? t('deactivate') : t('activate')"
-        @click="changeKeyState"
-        :disabled="!isChangeStateButtonActive"
-        :severity="isSelectedKeyActive ? 'danger' : 'success'"
-        class="text-sm"
-      />
-    </div>
-  </div>
+    </template>
+  </Dialog>
 </template>

--- a/src/components/NodeCredsTable.vue
+++ b/src/components/NodeCredsTable.vue
@@ -7,17 +7,19 @@
  * Features:
  * - Fetches API key list and broker node metadata from the AKTIN Broker
  * - Automatically updates on credential or key list changes
- * - Emits `update:selectedApiKey` when a row is selected
+ * - Shows the connected-node count and toggles the selected key's state
  * - Supports search, filtering, and toggling inactive keys
  * - Displays API keys in a masked preview format in the table
  */
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import BrokerConnection from "../services/BrokerConnection";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
 import Checkbox from "primevue/checkbox";
 import InputText from "primevue/inputtext";
 import Button from "primevue/button";
+import Divider from "primevue/divider";
+import NodeCredsForm from "./NodeCredsForm.vue";
 import { FilterMatchMode } from "@primevue/core/api";
 import { useToast } from "primevue/usetoast";
 import { useI18n } from "vue-i18n";
@@ -30,12 +32,11 @@ const { t } = useI18n();
 
 const apiKeyList = ref<Record<string, any>[]>([]);
 const selectedRow = ref<Record<string, any> | null>(null);
-const selectedApiKey = ref<string>("");
 const showInactiveKeys = ref(false);
+const nodeCount = ref(0);
 
-const emit = defineEmits<{
-  (e: "update:selectedApiKey", value: string): void;
-}>();
+// Whether the selected key is active; drives the toggle button label/severity
+const isSelectedActive = computed(() => selectedRow.value?.isActive === true);
 
 /**
  * Global search filter for the DataTable.
@@ -79,6 +80,7 @@ async function fetchAndFormatApiKeyList(): Promise<Record<string, any>[]> {
       nodeResult.status === 200
         ? parseNodeIdMap(nodeResult.data)
         : new Map<string, string>();
+    nodeCount.value = nodeMap.size;
     return mergeApiKeysWithNodes(keyResult.data, nodeMap);
   }
   notifyStatusError(toast, t, keyResult.status, {
@@ -108,10 +110,27 @@ onMounted(async () => {
   });
 });
 
-watch(selectedRow, (newVal) => {
-  selectedApiKey.value = newVal ? `${newVal.apiKey};${newVal.isActive}` : "";
-  emit("update:selectedApiKey", selectedApiKey.value);
-});
+/** Activates or deactivates the selected key, then clears the selection. */
+async function toggleSelectedKey() {
+  const row = selectedRow.value;
+  if (!row) return;
+  const wasActive = isSelectedActive.value;
+  const status = wasActive
+    ? await BrokerConnection.deactivateApiKey(row.apiKey)
+    : await BrokerConnection.activateApiKey(row.apiKey);
+  if (status === 200) {
+    createSuccessToast(
+      toast,
+      t("success"),
+      wasActive ? t("keyDeactivated") : t("keyActivated")
+    );
+    selectedRow.value = null;
+    return;
+  }
+  notifyStatusError(toast, t, status, {
+    404: { title: "notFound", message: "keyNotFound" }
+  });
+}
 
 watch(showInactiveKeys, async () => {
   await updateApiKeyList();
@@ -137,24 +156,43 @@ watch(showInactiveKeys, async () => {
     </template>
 
     <template #header>
-      <div class="flex justify-content-between flex-wrap">
-        <div>
+      <div
+        class="flex justify-content-between flex-wrap align-items-center gap-2"
+      >
+        <!-- Status + filters -->
+        <div class="flex align-items-center gap-2">
+          <span class="text-color-secondary white-space-nowrap">
+            {{ t("connectedNodes") }}: {{ nodeCount }}
+          </span>
+          <Divider layout="vertical" />
           <InputText
             v-model="filters['global'].value"
             :placeholder="t('keywordSearch')"
             class="text-base text-color surface-overlay p-2 input_Field"
           />
           <i v-tooltip="t('keywordSearchInfo')" class="pi pi-info-circle p-2" />
+          <div class="flex align-items-center">
+            <Checkbox
+              v-model="showInactiveKeys"
+              :binary="true"
+              inputId="showInactive"
+            />
+            <label for="showInactive" class="ml-1">{{
+              t("showInactiveKeys")
+            }}</label>
+          </div>
         </div>
-        <div class="flex align-items-center mr-2">
-          <Checkbox
-            v-model="showInactiveKeys"
-            :binary="true"
-            inputId="showInactive"
+
+        <!-- Actions -->
+        <div class="flex align-items-center gap-2 mr-2">
+          <NodeCredsForm />
+          <Button
+            :label="isSelectedActive ? t('deactivate') : t('activate')"
+            :severity="isSelectedActive ? 'danger' : 'success'"
+            :disabled="!selectedRow"
+            size="small"
+            @click="toggleSelectedKey"
           />
-          <label for="showInactive" class="ml-1">{{
-            t("showInactiveKeys")
-          }}</label>
         </div>
       </div>
     </template>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -9,6 +9,7 @@
   "unauthorizedToViewKeys": "Sie sind nicht berechtigt, API-Schlüssel anzuzeigen",
   "nodeId": "#",
   "nodeHasNoId": "Knoten hat noch keine ID",
+  "connectedNodes": "Verbundene Nodes",
   "status": "Status",
   "keyIsActive": "API-Schlüssel ist aktiv",
   "keyIsInactive": "API-Schlüssel ist inaktiv",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,6 +9,7 @@
   "unauthorizedToViewKeys": "You are not authorized to view API keys",
   "nodeId": "#",
   "nodeHasNoId": "Node has no ID assigned",
+  "connectedNodes": "Connected nodes",
   "status": "Status",
   "keyIsActive": "API key is active",
   "keyIsInactive": "API key is inactive",

--- a/src/views/ApiKeyView.vue
+++ b/src/views/ApiKeyView.vue
@@ -2,23 +2,14 @@
 /**
  * ApiKeyView.vue
  *
- * Route view for API-key management; pairs the key table with the add/toggle
- * form and shares the selected key between them.
+ * Route view for API-key management; hosts the API-key table, which carries its
+ * own add/toggle controls in the header.
  */
-import { ref } from "vue";
 import NodeCredsTable from "../components/NodeCredsTable.vue";
-import NodeCredsForm from "../components/NodeCredsForm.vue";
-
-const selectedApiKey = ref("");
 </script>
 
 <template>
-  <div class="grid">
-    <div class="col-10 surface-200 border-round-md">
-      <NodeCredsTable @update:selectedApiKey="selectedApiKey = $event" />
-    </div>
-    <div class="col-2">
-      <NodeCredsForm :selectedKey="selectedApiKey" />
-    </div>
+  <div class="surface-200 border-round-md">
+    <NodeCredsTable />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Reworks the toolbar of the API-key management view for a cleaner, more
intuitive layout.

## Changes

- **Add key → dialog**: the always-visible side form is gone. A small `+`
  button in the table header opens a modal dialog holding the key-creation form
  (mirrors the config dialog). On success the form clears and the dialog closes.
- **Activate/deactivate → header button**: the toggle now lives in the header
  and acts on the selected row; its label/severity reflect the row's state.
- **Connected-node count**: the header shows `Connected nodes: N` (from the
  broker node list already fetched by the table).
- **Toolbar layout**: left = node count · divider · search · "show inactive";
  right = add button · activate/deactivate.
- **`ApiKeyView` simplified** to a full-width table; the `selectedApiKey`
  plumbing between table and form is removed.
- New locale key `connectedNodes` (de/en).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
